### PR TITLE
refactor: replace deprecated tasks and filters

### DIFF
--- a/src/main/java/io/kestra/plugin/prometheus/Trigger.java
+++ b/src/main/java/io/kestra/plugin/prometheus/Trigger.java
@@ -44,7 +44,7 @@ import lombok.experimental.SuperBuilder;
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ json(taskrun.value) }}"
+                        format: "{{ fromJson(taskrun.value) }}"
                 triggers:
                   - id: watch
                     type: io.kestra.plugin.prometheus.Trigger


### PR DESCRIPTION
Replaces deprecated task identifiers and Pebble filters with their current equivalents